### PR TITLE
Update dbd-oracle.asd

### DIFF
--- a/dbd-oracle.asd
+++ b/dbd-oracle.asd
@@ -12,7 +12,7 @@
   :long-description "A CL-DBI interface for ORACLE database based on
   OCI bindings provided by CLSQL library."
   :version (:read-file-form "VERSION")
-  :depends-on (:dbi :cffi-uffi-compat :cffi)
+  :depends-on (:dbi :cffi-uffi-compat :cffi :cl-syntax)
   :pathname "src"
   :components ((:file "package")
                (:file "oracle-constants")


### PR DESCRIPTION
Include explicit dependency on cl-syntax, as cl-dbi no longer depends on it.